### PR TITLE
Fix for situation, when Permission is String

### DIFF
--- a/Events/interactionCreate.js
+++ b/Events/interactionCreate.js
@@ -10,12 +10,9 @@ module.exports = async (bot, interaction) => {
         if (command && typeof command.runSlash == "function") {
             if (command.commandData.Permission) {
                 if (typeof command.commandData.Permission == "string") {
-                    if (Utils.hasRole(interaction.member, role, true)) {
-                        permissions.push(true);
-                    } else {
-                        permissions.push(false);
-                    }
-                } else if (command.commandData.Permission[0]) {
+                    command.commandData.Permission = [command.commandData.Permission]
+                }
+                if (command.commandData.Permission[0]) {
                     for (const role of command.commandData.Permission) {
                         if (Utils.hasRole(interaction.member, role, true)) {
                             permissions.push(true);

--- a/Events/messageCreate.js
+++ b/Events/messageCreate.js
@@ -45,7 +45,7 @@ module.exports = async (bot, message) => {
             }
             if (commands.commandData.Permission) {
                 if (typeof commands.commandData.Permission == "string") {
-                    commands.commandData.Permission = [commands.Permission];
+                    commands.commandData.Permission = [commands.commandData.Permission];
                 } else if (!commands.commandData.Permission[0]) {
                     commands.commandData.Permission = [];
                     commands.commandData.Permission.push("@everyone");

--- a/Events/ready.js
+++ b/Events/ready.js
@@ -36,6 +36,9 @@ module.exports = async (bot) => {
                 commandYMLData = SlashCmds.find(x => x.name.toLowerCase() == element.name.toLowerCase()),
                 cmdPerms = [];
             if (!commandYMLData.commandData.Permission.includes("@everyone")) {
+                if (typeof commandYMLData.commandData.Permission == "string") {
+                    commandYMLData.commandData.Permission = [commandYMLData.commandData.Permission]
+                }
                 for (let i = 0; i < commandYMLData.commandData.Permission.length; i++) {
                     const element2 = commandYMLData.commandData.Permission[i];
                     if (element2.toLowerCase() !== "@everyone") {


### PR DESCRIPTION
Fixes changing the Permission from String to Array for normal commands

Same problem for Slash Commands, but idk how to to fix this for them.