### PR TITLE
Support for defining addon version

### DIFF
--- a/AddonTemplate.js
+++ b/AddonTemplate.js
@@ -12,6 +12,7 @@ module.exports = {
         name: "Zorino",
         color: "#FFE400",
     },
+    _version: "1.0.0",
     _priority: 1,
     _customConfigs: {
         main: {

--- a/Modules/Handlers/AddonHandler.js
+++ b/Modules/Handlers/AddonHandler.js
@@ -93,6 +93,7 @@ module.exports = {
 
                 let Log = addon.log || addon._log;
                 let Author = addon.author || addon._author;
+                let Version = addon.version || addon._version;
                 let CustomConfig = addon.customConfigs || addon._customConfigs || {};
                 let Dependencies = addon.dependencies || addon._dependencies;
 
@@ -119,19 +120,19 @@ module.exports = {
                                         } else if (typeof Author == "object" && typeof Author.name == "string") {
                                             console.log(chalk.hex(Author.color || "#007bff").bold(`[${Author.name}] `) + _log);
                                         } else {
-                                            Utils.logInfo(`${chalk.bold(Name)} addon has been loaded.`);
+                                            Utils.logInfo(`${chalk.bold(Name)} addon has been loaded.${Version ? " Version: " + chalk.bold(Version): ""}`);
                                         }
                                     } else if (typeof Log == "function") {
                                         await Log();
                                     } else {
-                                        Utils.logInfo(`${chalk.bold(Name)} addon has been loaded.`);
+                                        Utils.logInfo(`${chalk.bold(Name)} addon has been loaded.${Version ? " Version: " + chalk.bold(Version): ""}`);
                                     }
                                 }
                             } else {
                                 Utils.logError(`[AddonHandler] Unable to execute addon ${chalk.bold(Name)} as no function was found.`);
                             }
                         } else if (installed == "no-install but dependencies") {
-                            Utils.logError(`[AddonHandler] ${chalk.bold(Name)} addon requires ${chalk.bold(Dependencies.length)} node modules to be installed. Please restart the bot with the ${chalk.bold("--no-install")} flag.`);
+                            Utils.logError(`[AddonHandler] ${chalk.bold(Name)} addon requires ${chalk.bold(Dependencies.length)} node modules to be installed. Please restart the bot without the ${chalk.bold("--no-install")} flag.`);
                         }
                     })
                 })


### PR DESCRIPTION
## Changes

- Added support for defining addon version.
  - Added usage in `AddonTemplate.js`.
- Fixed small typo issue.
  - Reference: [Message on BrayanBot Discord server](https://discord.com/channels/940313316658642984/940971220466302976/957028843540082708)

## Screenshots
![image](https://user-images.githubusercontent.com/40821945/160253169-085df8b1-1bb6-4c35-b3a8-f27e488fb87e.png)

## Notes
If addon version is not defined, normal(current) info will be sent.

