### PR TITLE
Fix | messageCreate | Permissions handling fixes

### DIFF
--- a/Events/messageCreate.js
+++ b/Events/messageCreate.js
@@ -53,12 +53,13 @@ module.exports = async (bot, message) => {
                     const hasRole = Utils.hasRole(message.member, permission, false);
                     const userPermission = Utils.parseUser(permission, message.guild);
 
+                    if (!hasRole && !userPermission)
+                        Utils.logWarning(`Command ${chalk.bold(commands.name)} - ${chalk.bold(permission)} is not a valid User/Role.`)
+                    
                     if (hasRole) {
                         permissions.push(true)
                     } else if (userPermission && userPermission.id == message.member.id) {
                         permissions.push(true)
-                    } else {
-                        Utils.logWarning(`Command ${chalk.bold(commands.name)} - ${chalk.bold(permission)} is not a valid User/Role.`)
                     }
                 })
             }
@@ -70,9 +71,15 @@ module.exports = async (bot, message) => {
                 variables: [
                     ...Utils.userVariables(message.member),
                     {
-                        searchFor: /{roles}/g, replaceWith: commands.commandData.Permission.map((x) => {
-                            let role = Utils.findRole(x, message.guild, true);
-                            if (role) return roleMention(role.id);
+                        searchFor: /{perms}/g, replaceWith: commands.commandData.Permission.map((x) => {
+                            if (!!Utils.findRole(x, message.guild, false)) {
+                                let role = Utils.findRole(x, message.guild, true);
+                                if (role) return roleMention(role.id);
+                            }
+                            if (!!Utils.parseUser(x, message.guild)) {
+                                let user = Utils.parseUser(x, message.guild, true);
+                                if (user) return userMention(user.id);
+                            }
                         }).join(", "),
                     },
                 ],


### PR DESCRIPTION
## This PR fixes 2 things in permission handling in `messageCreate.js`
1. Fix for non-existing role/user
> Current: 
> - Error is being send even if role/user exists

> This PR: 
> - Error is being send only if role/user doesn't exist
2. Fix for permission embed
> Current: 
> - `{roles}` instead of `{perms}`
> - No support for user permissions

> This PR:
> - `{perms}` as it's used in `lang.yml`
> - Support for user permissions