### PR TITLE
New setupMessage.js options

### DIFF
--- a/Modules/Utils/setupMessage.js
+++ b/Modules/Utils/setupMessage.js
@@ -154,7 +154,7 @@ module.exports = (settings, ephemeral = false, tts = false, disableMentions = fa
                     if (Author) Author = Author.replace(variable.searchFor, variable.replaceWith);
                     if (AuthorAvatarImage) AuthorAvatarImage = AuthorAvatarImage.replace(variable.searchFor, variable.replaceWith);
                     if (AuthorURL) AuthorURL = AuthorURL.replace(variable.searchFor, variable.replaceWith);
-                    if (Color) Color = Color.replace(variable.searchFor, variable.replaceWith);
+                    if (Color && typeof Color == "string") Color = Color.replace(variable.searchFor, variable.replaceWith);
                     if (Image) Image = Image.replace(variable.searchFor, variable.replaceWith);
                     if (URL) URL = URL.replace(variable.searchFor, variable.replaceWith);
                 });

--- a/Modules/Utils/setupMessage.js
+++ b/Modules/Utils/setupMessage.js
@@ -29,7 +29,13 @@ const rowStructure = [
     3: rowStructure,
     4: rowStructure,
     5: rowStructure,
-}, messageStructure = {
+}, fileStructure = [
+    {
+        Path: String,
+        Name: String,
+        Description: String,
+    },
+], messageStructure = {
     configPath: {
         Content: String,
         Embeds: [
@@ -56,6 +62,7 @@ const rowStructure = [
             },
         ],
         Components: componentsStructure,
+        Files: fileStructure,
     },
     variables: [{ searchFor: RegExp, replaceWith: String }],
 };
@@ -69,7 +76,7 @@ const rowStructure = [
  * @param {componentsStructure} components
  * @returns
  */
-module.exports = (settings, ephemeral = false, tts = false, disableMentions = false, components = null) => {
+module.exports = (settings, ephemeral = false, tts = false, disableMentions = false, components = null, files = null) => {
     const { config, lang, commands, client } = require("../../index"),
         Utils = require("../Utils");
 
@@ -80,7 +87,7 @@ module.exports = (settings, ephemeral = false, tts = false, disableMentions = fa
         { searchFor: /{brand-name}/g, replaceWith: config.Branding.Name },
         { searchFor: /{brand-logo}/g, replaceWith: config.Branding.Logo },
         { searchFor: /{brand-link}/g, replaceWith: config.Branding.Link },
-    ], Embeds, Content, Components, Ephemeral = false, TTS = false, DisableMentions = false;
+    ], Embeds, Content, Components, Files, Ephemeral = false, TTS = false, DisableMentions = false;
 
     if (settings.variables && Array.isArray(settings.variables))
         settings.variables.forEach(x => Variables.push(x));
@@ -93,6 +100,8 @@ module.exports = (settings, ephemeral = false, tts = false, disableMentions = fa
         Embeds = settings.configPath.Embed || settings.configPath.embed;
     if (components || settings.components || settings.configPath.Components || settings.configPath.components)
         Components = components || settings.components || settings.configPath.Components || settings.configPath.components;
+    if (files || settings.files || settings.configPath.Files || settings.configPath.files)
+        Files = files || settings.files || settings.configPath.Files || settings.configPath.files;
     if (tts || settings.configPath.TTS || settings.configPath.Tts || settings.configPath.tts)
         TTS = true;
     if (disableMentions || settings.configPath.DisableMentions || settings.configPath.disableMentions || settings.configPath.disablementions)
@@ -145,6 +154,7 @@ module.exports = (settings, ephemeral = false, tts = false, disableMentions = fa
                     if (Author) Author = Author.replace(variable.searchFor, variable.replaceWith);
                     if (AuthorAvatarImage) AuthorAvatarImage = AuthorAvatarImage.replace(variable.searchFor, variable.replaceWith);
                     if (AuthorURL) AuthorURL = AuthorURL.replace(variable.searchFor, variable.replaceWith);
+                    if (Color) Color = Color.replace(variable.searchFor, variable.replaceWith);
                     if (Image) Image = Image.replace(variable.searchFor, variable.replaceWith);
                     if (URL) URL = URL.replace(variable.searchFor, variable.replaceWith);
                 });
@@ -395,6 +405,33 @@ module.exports = (settings, ephemeral = false, tts = false, disableMentions = fa
                 messageData.components.push(rows[x]);
     } else if (Components) {
         messageData.components = Components;
+    }
+
+    if (Files && Array.isArray(Files) && Files[0]) {
+        messageData.files = [];
+        for (let i = 0; i < Files.length; i++) {
+            const fileSettings = Files[i];
+            let File = fileSettings.Path || fileSettings.path || fileSettings.URL || fileSettings.url || fileSettings,
+                Name = fileSettings.Name || fileSettings.name,
+                Description = fileSettings.Description || fileSettings.description;
+            
+            if (Variables && typeof Variables === "object") Variables.forEach((variable) => {
+                if (File) File = File.replace(variable.searchFor, variable.replaceWith);
+                if (Name) Name = Name.replace(variable.searchFor, variable.replaceWith);
+                if (Description) Description = Description.replace(variable.searchFor, variable.replaceWith);
+            })
+
+            if (!File) {
+                Utils.logError(`[Utils] [setupMessage] File is required for file to work.`);
+            }
+
+            if (Name) messageData.files.push({
+                attachment: File,
+                name: Name,
+                description: Description || null,
+            })
+            else messageData.files.push(File);
+        }
     }
 
     if (DisableMentions)


### PR DESCRIPTION
# setupMessage changes
This PR is coming with two new features:
1. Option to use variables in Embed Color (Idk why this wasn't added before but won't ask)
2. Option to attach files to message

## Attach files option
As I said before, with these changes you can attach files to your messages - using online link or file path.

Example Format:
```yml
Files:
  - Path: "https://raw.githubusercontent.com/BrayanBotDev/BrayanBot/main/README.md"
    Name: "TestFile.md" 
    Description: "This is a test file"
```

You can also use only file path/link(string) instead of File Object.
`Description` option is optional BUT if you want to use it, `Name` is required!

## Info
All changes has been tested and are working as intended.